### PR TITLE
flake8 combines both pep8 and pyflakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 - pip install -r requirements.txt
 - pip install coverage flake8
 script:
-- flake8 .
+- flake8 --max-line-length=82 elections
 - export TEST_STATE='CA'
 - coverage run tests.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 python:
-- '2.6'
 - '2.7'
 install:
 - pip install -r requirements.txt
+- pip install coverage flake8
 script:
-- pep8 elections
-- pyflakes elections
+- flake8 .
 - export TEST_STATE='CA'
 - coverage run tests.py
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,9 @@ PyYAML==3.11
 Pygments==1.4
 Sphinx==1.1.2
 argparse
-coverage==3.7.1
 docutils==0.8.1
 latimes-calculate==0.1.8
-python-coveralls==2.4.2
 python-dateutil==1.5
-requests==2.2.1
+requests==2.18.4
 sh==1.09
-six==1.6.1
-pep8
-pyflakes
+six==1.11.0


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) is a superset of pep8 (pycodestyle) and pyflakes.  It also adds some useful tests of its own.

Testing tools like coverage, flake8, pep8, and pyflakes should not be in __requirements.txt__ because they are _optional_ for end users.